### PR TITLE
support delete: if form or data is present, validate

### DIFF
--- a/lib/superintendent/request/validator.rb
+++ b/lib/superintendent/request/validator.rb
@@ -9,7 +9,7 @@ module Superintendent::Request
       'POST' => 'create',
       'PATCH' => 'update',
       'PUT' => 'update',
-      'DELETE' => 'destroy'
+      'DELETE' => 'delete'
     }.freeze
 
     DEFAULT_OPTIONS = {
@@ -41,7 +41,7 @@ module Superintendent::Request
           return respond_404 # Return a 404 if no form was found.
         end
 
-        if form.present? || request_data.present?
+        unless skip_validation?(request, form)
           return respond_404 if form.nil?
           errors = JSON::Validator.fully_validate(
             form, request_data, { errors_as_objects: true })
@@ -56,6 +56,11 @@ module Superintendent::Request
     end
 
     private
+
+    def skip_validation?(request, form)
+      request.request_method == 'DELETE' && form.nil? &&
+        request.request_parameters.blank?
+    end
 
     # Parameters that are not in the form are removed from the request so they
     # never reach the controller.

--- a/test/test_request_validator.rb
+++ b/test/test_request_validator.rb
@@ -84,7 +84,7 @@ class UserRelationshipsMotherForm
     form
   end
 
-  def self.destroy
+  def self.delete
     form
   end
 
@@ -115,6 +115,9 @@ class UserRelationshipsMotherForm
     }
   end
   private_class_method :form
+end
+
+class NoMethodsForm
 end
 
 class UserRelationshipsThingForm
@@ -315,6 +318,16 @@ class RequestValidatorTest < Minitest::Test
                    'CONTENT_TYPE' => 'application/vnd.api+json')
     status, headers, body = @validator.call(env)
     assert_equal 200, status
+  end
+
+  def test_no_form_method
+    ['POST', 'PATCH', 'PUT'].each do |verb|
+      env = mock_env('/no_methods/NM5d251f5d477f42039170ea968975011b', verb,
+                     'CONTENT_TYPE' => 'application/vnd.api+json')
+      status, headers, body = @validator.call(env)
+      assert_equal 404, status
+    end
+
   end
 
   def test_plural_relationships_use_singular_form

--- a/test/test_request_validator.rb
+++ b/test/test_request_validator.rb
@@ -81,6 +81,14 @@ end
 
 class UserRelationshipsMotherForm
   def self.update
+    form
+  end
+
+  def self.destroy
+    form
+  end
+
+  def self.form
     {
       "type" => "object",
       "properties": {
@@ -106,6 +114,7 @@ class UserRelationshipsMotherForm
       ]
     }
   end
+  private_class_method :form
 end
 
 class UserRelationshipsThingForm
@@ -230,6 +239,19 @@ class RequestValidatorTest < Minitest::Test
     assert_equal 200, status
   end
 
+  def test_relationships_400
+    params = {
+      data: {
+        id: 'US5d251f5d477f42039170ea968975011b',
+        type: 'fathers'
+      }
+    }
+    env = mock_env('/users/US5d251f5d477f42039170ea968975011b/relationships/mother', 'PUT',
+                   input: JSON.generate(params), 'CONTENT_TYPE' => 'application/vnd.api+json')
+    status, headers, body = @validator.call(env)
+    assert_equal 400, status
+  end
+
   def test_relationships_no_form_404
     params = {
       data: {
@@ -243,17 +265,56 @@ class RequestValidatorTest < Minitest::Test
     assert_equal 404, status
   end
 
-  def test_relationships_400
+  def test_relationships_delete_200
     params = {
       data: {
         id: 'US5d251f5d477f42039170ea968975011b',
-        type: 'fathers'
+        type: 'mothers'
       }
     }
-    env = mock_env('/users/US5d251f5d477f42039170ea968975011b/relationships/mother', 'PUT',
+    env = mock_env('/users/US5d251f5d477f42039170ea968975011b/relationships/mother', 'DELETE',
+                   input: JSON.generate(params), 'CONTENT_TYPE' => 'application/vnd.api+json')
+    status, headers, body = @validator.call(env)
+    assert_equal 200, status
+  end
+
+  def test_relationships_delete_400_bad_request
+    params = {
+      data: {
+        id: 'US5d251f5d477f42039170ea968975011b'
+      }
+    }
+    env = mock_env('/users/US5d251f5d477f42039170ea968975011b/relationships/mother', 'DELETE',
                    input: JSON.generate(params), 'CONTENT_TYPE' => 'application/vnd.api+json')
     status, headers, body = @validator.call(env)
     assert_equal 400, status
+  end
+
+  def test_relationships_delete_400_no_body
+    env = mock_env('/users/US5d251f5d477f42039170ea968975011b/relationships/mother', 'DELETE',
+                   'CONTENT_TYPE' => 'application/vnd.api+json')
+    status, headers, body = @validator.call(env)
+    assert_equal 400, status
+  end
+
+  def test_relationships_delete_404_no_form_method
+    params = {
+      data: {
+        id: 'US5d251f5d477f42039170ea968975011b',
+        type: 'users'
+      }
+    }
+    env = mock_env('/users/US5d251f5d477f42039170ea968975011b', 'DELETE',
+                   input: JSON.generate(params), 'CONTENT_TYPE' => 'application/vnd.api+json')
+    status, headers, body = @validator.call(env)
+    assert_equal 404, status
+  end
+
+  def test_delete_200_no_body_no_form_method
+    env = mock_env('/users/US5d251f5d477f42039170ea968975011b', 'DELETE',
+                   'CONTENT_TYPE' => 'application/vnd.api+json')
+    status, headers, body = @validator.call(env)
+    assert_equal 200, status
   end
 
   def test_plural_relationships_use_singular_form


### PR DESCRIPTION
In json api deletes have bodies on relationships, but not all deletes have bodies. We need to optionally support bodies on delete. If the method is defined or a body is passed in, we should verify it. If no form is defined and no body passed in that is fine as well.

This PR supports the described behavior. If the form has a `destroy` method or `params` are passed into a `delete` request, the `params` will be validated against the form. 

I need to chat with @remear to see if he likes this direction, because there is some weirdness.

Previously if a method had no form, but had data a Runtime error would be issued. This behavior was/is untested. Now we silently ignore it. I need to clarify the intent in this situation and add behavior and tests. Now we skip any method where the body is empty and the form method is not defined. This is nice for `delete`, and not too harmful for `create/update` (If the form method is not defined and no body supplied: update is a `noop` and create is neutered.)
