### PR TITLE
directly configure error class for each engine

### DIFF
--- a/lib/superintendent.rb
+++ b/lib/superintendent.rb
@@ -1,11 +1,7 @@
 module Superintendent
+  require 'superintendent/request/error'
   require 'superintendent/request/response'
   require 'superintendent/request/bouncer'
-  require 'superintendent/request/error'
   require 'superintendent/request/id'
   require 'superintendent/request/validator'
-  require 'dry-configurable'
-  extend Dry::Configurable
-
-  setting :error_klass, Superintendent::Request::Error, reader: true
 end

--- a/lib/superintendent/request/bouncer.rb
+++ b/lib/superintendent/request/bouncer.rb
@@ -10,7 +10,7 @@ module Superintendent
           'application/json',
           'application/x-www-form-urlencoded'
         ],
-        :error_class => Superintendent::Request::Error
+        error_class: Superintendent::Request::Error
       }
 
       def initialize(app, opts={})

--- a/lib/superintendent/request/bouncer.rb
+++ b/lib/superintendent/request/bouncer.rb
@@ -9,7 +9,8 @@ module Superintendent
         supported_content_types: [
           'application/json',
           'application/x-www-form-urlencoded'
-        ]
+        ],
+        :error_class => Superintendent::Request::Error
       }
 
       def initialize(app, opts={})
@@ -21,6 +22,7 @@ module Superintendent
 
         if required_keys_missing?
           return respond_400(
+            @options[:error_class],
             [
               {
                 code: 'headers-missing',
@@ -34,6 +36,7 @@ module Superintendent
         if %w[POST PUT PATCH].include? @request.request_method
           if unsupported_content_type?
             return respond_400(
+              @options[:error_class],
               [
                 {
                   code: 'content-type-unsupported',

--- a/lib/superintendent/request/response.rb
+++ b/lib/superintendent/request/response.rb
@@ -7,19 +7,19 @@ module Superintendent::Request
       [404, {'Content-Type' => JSON_API_CONTENT_TYPE}, ['']]
     end
 
-    def respond_400(errors)
+    def respond_400(error_class, errors)
       [
         400,
         {'Content-Type' => JSON_API_CONTENT_TYPE},
         [
-          JSON.pretty_generate( errors: attributes_to_errors(errors))
+          JSON.pretty_generate( errors: attributes_to_errors(error_class, errors))
         ]
       ]
     end
 
-    def attributes_to_errors(errors)
+    def attributes_to_errors(error_class, errors)
       errors.map do |attributes|
-        Superintendent.config.error_klass.new(
+        error_class.new(
           {
             id: request_id,
             status: 400

--- a/lib/superintendent/request/validator.rb
+++ b/lib/superintendent/request/validator.rb
@@ -14,8 +14,8 @@ module Superintendent::Request
     }.freeze
 
     DEFAULT_OPTIONS = {
-      :monitored_content_types => ['application/json'],
-      :error_class => Superintendent::Request::Error
+      monitored_content_types: ['application/json'],
+      error_class: Superintendent::Request::Error
     }.freeze
 
     PARAMS_WRAPPER_KEYS = ['_json', '_jsonapi'].freeze

--- a/lib/superintendent/request/validator.rb
+++ b/lib/superintendent/request/validator.rb
@@ -14,7 +14,8 @@ module Superintendent::Request
     }.freeze
 
     DEFAULT_OPTIONS = {
-      :monitored_content_types => ['application/json']
+      :monitored_content_types => ['application/json'],
+      :error_class => Superintendent::Request::Error
     }.freeze
 
     PARAMS_WRAPPER_KEYS = ['_json', '_jsonapi'].freeze
@@ -22,7 +23,8 @@ module Superintendent::Request
     RELATIONSHIPS = /^relationships$/.freeze
 
     def initialize(app, opts={})
-      @app, @options = app, DEFAULT_OPTIONS.merge(opts)
+      @app = app
+      @options = DEFAULT_OPTIONS.merge(opts)
     end
 
     def call(env)
@@ -49,7 +51,7 @@ module Superintendent::Request
             request_data,
             { errors_as_objects: true }
           )
-          return respond_400(serialize_errors(errors)) if errors.present?
+          return respond_400(@options[:error_class], serialize_errors(errors)) if errors.present?
           drop_extra_params!(
             form,
             request_data

--- a/test/test_request_bouncer.rb
+++ b/test/test_request_bouncer.rb
@@ -2,7 +2,6 @@ require_relative 'test_helper'
 
 class RequestBouncerTest < Minitest::Test
   def setup
-    Superintendent.config.error_klass = Superintendent::Request::Error
     @app = lambda { |env| [200, {}, []] }
     @bouncer = Superintendent::Request::Bouncer.new(
       @app, { supported_content_types: ['application/json'] }
@@ -59,10 +58,12 @@ class RequestBouncerTest < Minitest::Test
   end
 
   def test_required_header_missing_alternate_error_class
-    Superintendent.config.error_klass = MyError
     env = mock_env()
     bouncer = Superintendent::Request::Bouncer.new(
-      @app, { required_headers: ['Custom-Header'] }
+      @app, {
+        required_headers: ['Custom-Header'],
+        error_class: MyError
+      }
     )
 
     status, headers, body = bouncer.call(env)

--- a/test/test_request_bouncer.rb
+++ b/test/test_request_bouncer.rb
@@ -53,7 +53,11 @@ class RequestBouncerTest < Minitest::Test
 
     status, headers, body = bouncer.call(env)
     assert_equal 400, status
-    expected = {"code"=>"headers-missing", "title"=>"Headers missing", "detail"=>"Required headers were not present in the request"}
+    expected = {
+      "code" => "headers-missing",
+      "title" => "Headers missing",
+      "detail" => "Required headers were not present in the request"
+    }
     validate_error(expected, body)
   end
 
@@ -68,7 +72,14 @@ class RequestBouncerTest < Minitest::Test
 
     status, headers, body = bouncer.call(env)
     assert_equal 400, status
-    expected = {"id"=> nil, "status"=>400, "code"=>"headers-missing", "title"=>"Headers missing", "detail"=>"Required headers were not present in the request", "type"=>"errors"}
+    expected = {
+      "id" => nil,
+      "status" => 400,
+      "code" => "headers-missing",
+      "title" => "Headers missing",
+      "detail" => "Required headers were not present in the request",
+      "type" => "errors"
+    }
     errors = JSON.parse(body.first)['errors']
     assert_equal expected, errors.first
   end
@@ -78,7 +89,11 @@ class RequestBouncerTest < Minitest::Test
       env = mock_env(method, { 'CONTENT_TYPE' => 'junk' })
       status, headers, body = @bouncer.call(env)
       assert_equal 400, status
-      expected = {"code"=>"content-type-unsupported", "title"=>"Request content-type is unsupported", "detail"=>"junk is not a supported content-type"}
+      expected = {
+        "code" => "content-type-unsupported",
+        "title" => "Request content-type is unsupported",
+        "detail" => "junk is not a supported content-type"
+      }
       validate_error(expected, body)
     end
   end
@@ -98,7 +113,11 @@ class RequestBouncerTest < Minitest::Test
     env = mock_env('POST', { 'CONTENT_TYPE' => 'application/json' })
     status, headers, body = bouncer.call(env)
     assert_equal 400, status
-    expected = {"code"=>"content-type-unsupported", "title"=>"Request content-type is unsupported", "detail"=>"application/json is not a supported content-type"}
+    expected = {
+      "code" => "content-type-unsupported",
+      "title" => "Request content-type is unsupported",
+      "detail" => "application/json is not a supported content-type"
+    }
     validate_error(expected, body)
   end
 

--- a/test/test_request_validator.rb
+++ b/test/test_request_validator.rb
@@ -446,7 +446,11 @@ class RequestValidatorTest < Minitest::Test
     env = mock_env('/users', 'POST', input: JSON.generate(params))
     status, headers, body = @validator.call(env)
     assert_equal 400, status
-    expected = {"code"=>"type-v4", "title"=>"TypeV4", "detail"=>"The property '' of type null did not match the following type: object"}
+    expected = {
+      "code" => "type-v4",
+      "title" => "TypeV4",
+      "detail" => "The property '' of type null did not match the following type: object"
+    }
     validate_error(expected, body)
   end
 
@@ -465,7 +469,14 @@ class RequestValidatorTest < Minitest::Test
     env = mock_env('/users', 'POST', input: JSON.generate(params))
     status, headers, body = validator.call(env)
     assert_equal 400, status
-    expected = {"id" => nil, "status"=>400, "code"=>"type-v4", "title"=>"TypeV4", "detail"=>"The property '' of type null did not match the following type: object", "type"=>"errors"}
+    expected = {
+      "id" => nil,
+      "status" => 400,
+      "code" => "type-v4",
+      "title" => "TypeV4",
+      "detail" => "The property '' of type null did not match the following type: object",
+      "type" => "errors"
+    }
     errors = JSON.parse(body.first)['errors']
     assert_equal expected, errors.first
   end
@@ -481,7 +492,11 @@ class RequestValidatorTest < Minitest::Test
     status, headers, body = @validator.call(env)
     assert_equal 400, status
     # TODO: this seems like the wrong error
-    expected = {"code"=>"type-v4", "title"=>"TypeV4", "detail"=>"The property '' of type null did not match the following type: object"}
+    expected = {
+      "code" => "type-v4",
+      "title" => "TypeV4",
+      "detail" => "The property '' of type null did not match the following type: object"
+    }
     validate_error(expected, body)
   end
 


### PR DESCRIPTION
ℹ️ targeting the `refactor` branch, not `master`
Move the config to one place.